### PR TITLE
chore(context): make context optional and show help as default (no parameters given)

### DIFF
--- a/examples/python-5.6-cody-client/cody_chat.py
+++ b/examples/python-5.6-cody-client/cody_chat.py
@@ -6,6 +6,7 @@ to provide context-aware responses based on repository content.
 import argparse
 import json
 import os
+import sys
 
 import requests
 
@@ -218,19 +219,20 @@ def main():
     parser.add_argument(
         "--context-repo",
         action="append",
-        help="Repository name (can be used multiple times)",
+        help="Repository name (can be used multiple times) [Optional]",
     )
     parser.add_argument("--message", type=str, help="Query message")
+
+    if len(sys.argv) == 1:
+        parser.print_help(sys.stderr)
+        sys.exit(1)
 
     args = parser.parse_args()
 
     if not args.message:
         raise ValueError("Error: --message argument is required.")
 
-    if not args.context_repo:
-        raise ValueError("Error: --context-repo argument is required.")
-
-    repo_names = args.context_repo
+    repo_names = args.context_repo or []
     query = args.message
     cody_chat(repo_names, query)
 


### PR DESCRIPTION
Make context optional and show help as default (no parameters given).

```
» python3 cody_chat.py
usage: cody_chat.py [-h] [--context-repo CONTEXT_REPO] [--message MESSAGE]

Cody Chat CLI

options:
  -h, --help            show this help message and exit
  --context-repo CONTEXT_REPO
                        Repository name (can be used multiple times)  [Optional]
  --message MESSAGE     Query message
```
```
» python3 cody_chat.py --message "What is the collour of the sun?"
The context provided does not contain specific information about the color of the sun. However, based on general knowledge, the sun appears yellow or white when observed from Earth. This is due to the scattering of shorter wavelengths of light (blue and violet) by the Earth's atmosphere, leaving the longer wavelengths (yellow, orange, and red) more visible. In space, without the atmospheric scattering, the sun would appear white.
```
```
» python3 cody_chat.py --message "What is the collour of the sun?" --context-repo example.org/repo/sanitized
Based on the provided context, the color of the sun is blue. This ensures that the parsing was correct and the AI model sourced its answer from the right place.
```